### PR TITLE
Release 0.1.1 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.1] - 2022-06-10
+### Changed
+- Serializers and views detail implementations; Reduced DRF's black magic
+- `README.md`'s documentation
+
 ## [0.1.0] - 2022-06-08
 ### Added
 - Contact API


### PR DESCRIPTION
## [0.1.1] - 2022-06-10
### Changed
- Serializers and views detail implementations; Reduced DRF's black magic
- `README.md`'s documentation